### PR TITLE
Ensure round-trip serialization is consistent

### DIFF
--- a/jackson/src/main/java/tech/uom/lib/jackson/UnitJacksonModule.java
+++ b/jackson/src/main/java/tech/uom/lib/jackson/UnitJacksonModule.java
@@ -108,7 +108,7 @@ public class UnitJacksonModule extends SimpleModule {
             JsonToken currentToken = jsonParser.getCurrentToken();
 
             if (currentToken == JsonToken.VALUE_STRING) {
-                return UCUMFormat.getInstance(Variant.CASE_INSENSITIVE).parse(jsonParser.getText(), new ParsePosition(0));
+                return UCUMFormat.getInstance(Variant.CASE_SENSITIVE).parse(jsonParser.getText(), new ParsePosition(0));
             }
             throw deserializationContext.wrongTokenException(jsonParser, String.class,
                     JsonToken.VALUE_STRING,

--- a/jackson/src/test/java/tech/uom/lib/jackson/TestUnitJacksonModule.java
+++ b/jackson/src/test/java/tech/uom/lib/jackson/TestUnitJacksonModule.java
@@ -40,10 +40,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
-import tech.uom.lib.jackson.UnitJacksonModule;
 import systems.uom.ucum.UCUM;
 import tec.units.indriya.unit.Units;
 
@@ -51,6 +49,7 @@ import javax.measure.Unit;
 
 import static tec.units.indriya.AbstractUnit.ONE;
 import static tec.units.indriya.unit.MetricPrefix.KILO;
+import static tec.units.indriya.unit.MetricPrefix.MEGA;
 import static tec.units.indriya.unit.MetricPrefix.MILLI;
 import static org.junit.Assert.*;
 
@@ -130,10 +129,16 @@ public class TestUnitJacksonModule {
 	}
 
 	@Test
-	@Ignore("solve km formatting") // TODO solve km parsing
 	public void testParseLengthKm() throws Exception {
 		final Unit<?> parsedUnit = parse("\"km\"", Unit.class);
 		assertEquals("The Unit<Length> in the parsed JSON doesn't match", KILO(Units.METRE), parsedUnit);
+	}
+
+	@Test
+	public void testRoundTripSerialization() throws Exception {
+		String serialized = serialize(MEGA(UCUM.METER));
+		Unit<?> parsedUnit = parse(serialized, Unit.class);
+		assertEquals("The Unit<Length> in the parsed JSON doesn't match", MEGA(UCUM.METER), parsedUnit);
 	}
 
 	protected String serialize(Object objectToSerialize) throws IOException {


### PR DESCRIPTION
The serialization/de-serialization is not consistent, so if you are trying to use this to map between JSON and back, then it doesn't work for a subset of UCUM units.

I have also removed the `@Ignore` on the km test, but happy to revert this change.

Also, I chose to use case sensitive, as this usually leads to better human readable formats in the JSON structure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/uom-lib/38)
<!-- Reviewable:end -->
