### PR TITLE
Add openjdk8 and openjdk-ea to jdks in .travis.yml in order to increase coverage of JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: java
 jdk:
+- openjdk8
 - openjdk9
 - openjdk10
 - openjdk11
 - openjdk12
 - openjdk13
 - openjdk14
+- openjdk-ea
+


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/uom-lib/53)
<!-- Reviewable:end -->
