### PR TITLE
Version 2.0.1 of uom-lib-common fails declare its exported packages, making it not usable in an OSGi context

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -115,6 +115,9 @@
 			<plugin>
 				<groupId>biz.aQute.bnd</groupId>
 				<artifactId>bnd-maven-plugin</artifactId>
+ 				<configuration>
+ 					<bnd>-exportcontents: tech.uom.lib.common.*</bnd>
+ 				</configuration>
 			</plugin>
 
 			<!-- ======================================================= -->


### PR DESCRIPTION
Since version 2.0.1 of uom-lib-common the export of the two packages in this library was (I guess unintentionally) removed. This pull request addresses this issue by adding the required instruction to bnd to export the packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/uom-lib/65)
<!-- Reviewable:end -->
